### PR TITLE
Improve UI with dropbox-style uploader

### DIFF
--- a/src/components/ChartPanel.jsx
+++ b/src/components/ChartPanel.jsx
@@ -19,7 +19,7 @@ const COLORS = ["#60a5fa", "#10b981", "#facc15"];
 function ChartPanel({ type }) {
   if (type === "donut") {
     return (
-      <div className="h-64 p-4 border rounded">
+      <div className="h-64 p-4 border rounded-lg bg-white shadow">
         <ResponsiveContainer width="100%" height="100%">
           <PieChart>
             <Pie dataKey="value" data={dataPie} innerRadius={40} outerRadius={80}>
@@ -35,7 +35,7 @@ function ChartPanel({ type }) {
   }
 
   return (
-    <div className="h-64 p-4 border rounded">
+    <div className="h-64 p-4 border rounded-lg bg-white shadow">
       <ResponsiveContainer width="100%" height="100%">
         <BarChart data={dataBar}>
           <XAxis dataKey="name" />

--- a/src/components/FileUploader.jsx
+++ b/src/components/FileUploader.jsx
@@ -1,21 +1,60 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useRef, useState } from "react";
+import { ArrowUpTrayIcon } from "@heroicons/react/24/outline";
 
 function FileUploader() {
   const [files, setFiles] = useState([]);
+  const [dragging, setDragging] = useState(false);
+  const inputRef = useRef(null);
 
-  const handleFiles = useCallback((e) => {
-    const selected = Array.from(e.target.files);
+  const handleFiles = useCallback((filesList) => {
+    const selected = Array.from(filesList);
     setFiles((prev) => [...prev, ...selected]);
   }, []);
 
+  const onChange = useCallback(
+    (e) => {
+      handleFiles(e.target.files);
+    },
+    [handleFiles]
+  );
+
+  const onDrop = (e) => {
+    e.preventDefault();
+    setDragging(false);
+    if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+      handleFiles(e.dataTransfer.files);
+      e.dataTransfer.clearData();
+    }
+  };
+
+  const openFileDialog = () => {
+    inputRef.current?.click();
+  };
+
   return (
-    <div className="border-2 border-dashed border-gray-300 p-6 rounded-md text-center">
-      <input
-        type="file"
-        multiple
-        onChange={handleFiles}
-        className="mb-4"
-      />
+    <div className="space-y-4">
+      <div
+        className={`relative flex flex-col items-center justify-center p-8 border-2 border-dashed rounded-xl cursor-pointer transition-colors duration-200 ${dragging ? "border-blue-500 bg-blue-50" : "border-gray-300 bg-white hover:border-blue-400"}`}
+        onClick={openFileDialog}
+        onDragOver={(e) => {
+          e.preventDefault();
+          setDragging(true);
+        }}
+        onDragLeave={() => setDragging(false)}
+        onDrop={onDrop}
+      >
+        <input
+          ref={inputRef}
+          type="file"
+          multiple
+          onChange={onChange}
+          className="hidden"
+        />
+        <ArrowUpTrayIcon className="w-12 h-12 text-gray-400 mb-2" />
+        <p className="text-gray-600">
+          Drag & drop files here or <span className="text-blue-500 underline">browse</span>
+        </p>
+      </div>
       {files.length > 0 && (
         <ul className="mt-2 text-left list-disc list-inside text-sm">
           {files.map((f, idx) => (

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -4,7 +4,7 @@ import { BanknotesIcon } from "@heroicons/react/24/outline";
 
 function Header() {
   return (
-    <header className="bg-stone-50 border-b border-stone-200">
+    <header className="bg-white/80 backdrop-blur-sm shadow-sm">
       <div className="max-w-7xl mx-auto px-6 py-4 flex items-center justify-between">
         {/* Left Corner - Logo */}
         <Link to="/" className="flex items-center space-x-3 text-xl font-bold text-gray-800 hover:text-teal-600 transition-colors duration-200">

--- a/src/components/InsightCard.jsx
+++ b/src/components/InsightCard.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 function InsightCard({ text }) {
   return (
-    <div className="p-4 border rounded shadow-sm bg-white">
+    <div className="p-4 border rounded-lg bg-white shadow">
       {text}
     </div>
   );

--- a/src/components/ToggleView.jsx
+++ b/src/components/ToggleView.jsx
@@ -6,7 +6,7 @@ function ToggleView() {
     <div className="flex items-center space-x-4">
       <span className={view === "aggregated" ? "font-semibold" : ""}>Aggregated View</span>
       <button
-        className="relative inline-flex h-6 w-11 items-center rounded-full bg-gray-300"
+        className="relative inline-flex h-6 w-11 items-center rounded-full bg-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
         onClick={() => setView(view === "aggregated" ? "individual" : "aggregated")}
       >
         <span


### PR DESCRIPTION
## Summary
- modernize UI components with subtle shadows and rounded corners
- add drag-and-drop file uploader similar to Dropbox
- refine header style with translucent background

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684e8c47a3788327816d20013e5ec912