### PR TITLE
Gate dashboard until files processed

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ In the project directory, you can run:
 Runs the app in the development mode.\
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 
+The dashboard becomes available only after you upload and process files on the home page.
+
 The page will reload if you make edits.\
 You will also see any lint errors in the console.
 

--- a/src/App.js
+++ b/src/App.js
@@ -1,15 +1,18 @@
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Home from "./pages/Home";
 import Dashboard from "./pages/Dashboard";
+import { ProcessProvider } from "./context/ProcessContext";
 
 function App() {
   return (
-    <Router>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/dashboard" element={<Dashboard />} />
-      </Routes>
-    </Router>
+    <ProcessProvider>
+      <Router>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/dashboard" element={<Dashboard />} />
+        </Routes>
+      </Router>
+    </ProcessProvider>
   );
 }
 

--- a/src/components/FileUploader.jsx
+++ b/src/components/FileUploader.jsx
@@ -1,16 +1,22 @@
 import React, { useCallback, useRef, useState } from "react";
 import { ArrowUpTrayIcon } from "@heroicons/react/24/outline";
 import { motion } from "framer-motion";
+import { useProcess } from "../context/ProcessContext";
 
 function FileUploader() {
   const [files, setFiles] = useState([]);
   const [dragging, setDragging] = useState(false);
   const inputRef = useRef(null);
+  const { setIsProcessed } = useProcess();
 
-  const handleFiles = useCallback((filesList) => {
-    const selected = Array.from(filesList);
-    setFiles((prev) => [...prev, ...selected]);
-  }, []);
+  const handleFiles = useCallback(
+    (filesList) => {
+      const selected = Array.from(filesList);
+      setFiles((prev) => [...prev, ...selected]);
+      setIsProcessed(false);
+    },
+    [setIsProcessed]
+  );
 
   const onChange = useCallback(
     (e) => {

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,8 +1,10 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { BanknotesIcon } from "@heroicons/react/24/outline";
+import { useProcess } from "../context/ProcessContext";
 
 function Header() {
+  const { isProcessed } = useProcess();
   return (
     <header className="bg-gradient-to-r from-slate-700 to-gray-800 text-white shadow">
       <div className="max-w-7xl mx-auto px-6 py-4 flex items-center justify-between">
@@ -27,7 +29,13 @@ function Header() {
             <span className="absolute bottom-0 left-0 w-0 h-0.5 bg-yellow-300 group-hover:w-full transition-all duration-200"></span>
           </Link>
           <Link
-            to="/dashboard"
+            to={isProcessed ? "/dashboard" : "#"}
+            onClick={(e) => {
+              if (!isProcessed) {
+                e.preventDefault();
+                alert("Please upload files");
+              }
+            }}
             className="font-medium hover:text-yellow-300 transition-colors duration-200 relative group"
           >
             Dashboard

--- a/src/context/ProcessContext.js
+++ b/src/context/ProcessContext.js
@@ -1,0 +1,14 @@
+import React, { createContext, useContext, useState } from "react";
+
+const ProcessContext = createContext();
+
+export const ProcessProvider = ({ children }) => {
+  const [isProcessed, setIsProcessed] = useState(false);
+  return (
+    <ProcessContext.Provider value={{ isProcessed, setIsProcessed }}>
+      {children}
+    </ProcessContext.Provider>
+  );
+};
+
+export const useProcess = () => useContext(ProcessContext);

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -3,13 +3,26 @@ import Header from "../components/Header";
 import ToggleView from "../components/ToggleView";
 import ChartPanel from "../components/ChartPanel";
 import InsightCard from "../components/InsightCard";
+import { useProcess } from "../context/ProcessContext";
 
 function Dashboard() {
+  const { isProcessed } = useProcess();
   const [loading, setLoading] = useState(true);
   useEffect(() => {
     const t = setTimeout(() => setLoading(false), 1000);
     return () => clearTimeout(t);
   }, []);
+
+  if (!isProcessed) {
+    return (
+      <div className="min-h-screen flex flex-col bg-gradient-to-b from-white via-purple-50 to-pink-50">
+        <Header />
+        <main className="flex-grow flex items-center justify-center p-6">
+          <p className="text-lg text-gray-700">Please upload files</p>
+        </main>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen flex flex-col bg-gradient-to-b from-white via-purple-50 to-pink-50">

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,19 +1,22 @@
 import React, { useState } from "react";
 import Header from "../components/Header";
 import FileUploader from "../components/FileUploader";
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import ChartPanel from "../components/ChartPanel";
 import TrendChart from "../components/TrendChart";
+import { useProcess } from "../context/ProcessContext";
 
 function Home() {
   const navigate = useNavigate();
   const [processing, setProcessing] = useState(false);
+  const { setIsProcessed } = useProcess();
 
   const handleProcess = () => {
     if (processing) return;
     setProcessing(true);
     setTimeout(() => {
       setProcessing(false);
+      setIsProcessed(true);
       navigate("/dashboard");
     }, 2000);
   };
@@ -108,12 +111,12 @@ function Home() {
                 <h3 className="text-2xl font-semibold text-gray-800 mb-6 text-center">Get Started</h3>
                 <FileUploader />
                 <div className="text-center mt-6">
-                  <Link
-                    to="/dashboard"
-                    className="px-8 py-4 bg-gradient-to-r from-indigo-600 to-blue-600 text-white rounded-xl font-semibold hover:from-indigo-700 hover:to-blue-700 transform hover:scale-105 transition-all duration-200 shadow-lg inline-block"
+                  <button
+                    onClick={handleProcess}
+                    className="px-8 py-4 bg-gradient-to-r from-indigo-600 to-blue-600 text-white rounded-xl font-semibold hover:from-indigo-700 hover:to-blue-700 transform hover:scale-105 transition-all duration-200 shadow-lg inline-block disabled:opacity-60"
                   >
-                    Process Files →
-                  </Link>
+                    {processing ? "Processing..." : "Process Files →"}
+                  </button>
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary
- add global processing context
- process files via button then set processed state
- disable dashboard link until processing is complete
- show upload reminder if `/dashboard` accessed early
- document gating in README

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_684eb0cf7e408327955eec3eae6d6068