### PR TITLE
Fix build errors by importing useProcess

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router-dom";
 import ChartPanel from "../components/ChartPanel";
 import TrendChart from "../components/TrendChart";
 import PageContainer from "../components/PageContainer";
+import { useProcess } from "../context/ProcessContext";
 
 function Home() {
   const navigate = useNavigate();


### PR DESCRIPTION
## Summary
- ensure `useProcess` hook is imported in Home page

## Testing
- `npm run build`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684ec6774b3083279c501fb372751790