### PR TITLE
Fix context provider and header duplication

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,14 @@
 import React from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App";
+import { ProcessProvider } from "./context/ProcessContext";
 
-ReactDOM.render(
+const root = createRoot(document.getElementById("root"));
+root.render(
   <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-  document.getElementById("root")
+    <ProcessProvider>
+      <App />
+    </ProcessProvider>
+  </React.StrictMode>
 );

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from "react";
-import Header from "../components/Header";
 import ToggleView from "../components/ToggleView";
 import ChartPanel from "../components/ChartPanel";
 import InsightCard from "../components/InsightCard";
@@ -19,7 +18,6 @@ function Dashboard() {
   if (!isProcessed) {
     return (
       <div className="min-h-screen flex flex-col bg-gradient-to-b from-white via-purple-50 to-pink-50">
-        <Header />
         <main className="flex-grow flex items-center justify-center p-6">
           <p className="text-lg text-gray-700">Please upload files</p>
         </main>
@@ -29,7 +27,6 @@ function Dashboard() {
 
   return (
     <div className="min-h-screen flex flex-col bg-gradient-to-b from-white via-purple-50 to-pink-50">
-      <Header />
       <main className="flex-grow p-6 md:p-10">
         {loading ? (
           <div className="animate-pulse space-y-4">

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,10 +1,9 @@
 import React, { useState } from "react";
-import Header from "../components/Header";
 import FileUploader from "../components/FileUploader";
 import { useNavigate } from "react-router-dom";
 import ChartPanel from "../components/ChartPanel";
 import TrendChart from "../components/TrendChart";
-import PageContainer from "../components/PageContainer";
+import { useProcess } from "../context/ProcessContext";
 
 function Home() {
   const navigate = useNavigate();
@@ -28,7 +27,6 @@ function Home() {
 
   return (
     <div className="min-h-screen flex flex-col">
-      <Header />
       <main className="flex-grow">
         {/* Hero Section with Botanical Background */}
         <section className="min-h-screen relative bg-gradient-to-b from-slate-800 via-slate-700 to-slate-600 text-white overflow-hidden">


### PR DESCRIPTION
## Summary
- wrap app in `ProcessProvider`
- import `useProcess` in `Home` page
- remove duplicate `Header` components from pages

## Testing
- `CI=true npm test --silent -- --passWithNoTests`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ec6daab3c83279cf6a4d4d0f2802e