### PR TITLE
Implement working dark mode toggle

### DIFF
--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,8 +1,12 @@
 import React from 'react';
 
-function Card({ children, className = '' }) {
+function Card({ children, className = "" }) {
   return (
-    <div className={`rounded-xl border bg-white shadow ${className}`}>{children}</div>
+    <div
+      className={`rounded-xl border bg-white shadow dark:bg-gray-800 dark:border-gray-700 ${className}`}
+    >
+      {children}
+    </div>
   );
 }
 

--- a/src/components/DarkModeToggle.jsx
+++ b/src/components/DarkModeToggle.jsx
@@ -6,11 +6,22 @@ function DarkModeToggle() {
   const [enabled, setEnabled] = useState(false);
 
   useEffect(() => {
+    const stored = localStorage.getItem("theme");
+    if (stored) {
+      setEnabled(stored === "dark");
+    } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+      setEnabled(true);
+    }
+  }, []);
+
+  useEffect(() => {
     const root = document.documentElement;
     if (enabled) {
       root.classList.add("dark");
+      localStorage.setItem("theme", "dark");
     } else {
       root.classList.remove("dark");
+      localStorage.setItem("theme", "light");
     }
   }, [enabled]);
 
@@ -20,10 +31,10 @@ function DarkModeToggle() {
       <Switch.Root
         checked={enabled}
         onCheckedChange={setEnabled}
-        className="relative w-11 h-6 rounded-full bg-gray-300 data-[state=checked]:bg-purple-600 focus:outline-none focus:ring-2 focus:ring-purple-500"
+        className="relative w-11 h-6 rounded-full bg-gray-300 dark:bg-gray-600 data-[state=checked]:bg-purple-600 focus:outline-none focus:ring-2 focus:ring-purple-500"
       >
         <Switch.Thumb
-          className="block w-5 h-5 bg-white rounded-full shadow transition-transform translate-x-1 data-[state=checked]:translate-x-5"
+          className="block w-5 h-5 bg-white dark:bg-gray-200 rounded-full shadow transition-transform translate-x-1 data-[state=checked]:translate-x-5"
         />
       </Switch.Root>
       <MoonIcon className="w-5 h-5 text-purple-300" />

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -8,7 +8,7 @@ import { useProcess } from "../context/ProcessContext";
 function Header() {
   const { isProcessed } = useProcess();
   return (
-    <header className="bg-gradient-to-r from-slate-700 to-gray-800 text-white shadow">
+    <header className="bg-gradient-to-r from-slate-700 to-gray-800 dark:from-gray-900 dark:to-gray-950 text-white shadow">
       <PageContainer className="flex justify-between items-center py-4">
         {/* Left Corner - Logo */}
         <Link

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -4,7 +4,7 @@ import { Outlet } from 'react-router-dom';
 
 function Layout() {
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-screen flex flex-col bg-gradient-to-b from-white via-purple-50 to-pink-50 dark:from-gray-900 dark:via-gray-900 dark:to-gray-800 text-gray-900 dark:text-gray-100 transition-colors">
       <Header />
       <main className="flex-grow">
         <Outlet />

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,12 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  body {
+    @apply bg-gradient-to-b from-white via-purple-50 to-pink-50 text-gray-900;
+  }
+  html.dark body {
+    @apply bg-gradient-to-b from-gray-900 via-gray-800 to-gray-700 text-gray-100;
+  }
+}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -17,16 +17,16 @@ function Dashboard() {
 
   if (!isProcessed) {
     return (
-      <div className="min-h-screen flex flex-col bg-gradient-to-b from-white via-purple-50 to-pink-50">
+      <div className="min-h-screen flex flex-col bg-gradient-to-b from-white via-purple-50 to-pink-50 dark:from-gray-900 dark:via-gray-900 dark:to-gray-800">
         <main className="flex-grow flex items-center justify-center p-6">
-          <p className="text-lg text-gray-700">Please upload files</p>
+          <p className="text-lg text-gray-700 dark:text-gray-200">Please upload files</p>
         </main>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen flex flex-col bg-gradient-to-b from-white via-purple-50 to-pink-50">
+    <div className="min-h-screen flex flex-col bg-gradient-to-b from-white via-purple-50 to-pink-50 dark:from-gray-900 dark:via-gray-900 dark:to-gray-800">
       <main className="flex-grow p-6 md:p-10">
         {loading ? (
           <div className="animate-pulse space-y-4">

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -113,13 +113,13 @@ function Home() {
 
               {/* File Upload Section */}
               <div className="flex justify-center">
-                <div className="w-full sm:w-3/4 md:w-2/3 lg:w-1/2 bg-white/80 backdrop-blur-lg rounded-3xl shadow-2xl p-8">
-                  <h3 className="text-2xl font-semibold text-gray-800 mb-6 text-center">Get Started</h3>
+                <div className="w-full sm:w-3/4 md:w-2/3 lg:w-1/2 bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg rounded-3xl shadow-2xl p-8">
+                  <h3 className="text-2xl font-semibold text-gray-800 dark:text-gray-100 mb-6 text-center">Get Started</h3>
                     <FileUploader onFilesChange={setUploadedFiles} />
                     <div className="text-center mt-6 space-y-4">
                       <button
                         onClick={handleProcess}
-                        className="px-8 py-4 bg-gradient-to-r from-indigo-600 to-blue-600 text-white rounded-xl font-semibold hover:from-indigo-700 hover:to-blue-700 transform hover:scale-105 transition-all duration-200 shadow-lg inline-block"
+                        className="px-8 py-4 bg-gradient-to-r from-indigo-600 to-blue-600 dark:from-purple-700 dark:to-purple-900 text-white rounded-xl font-semibold hover:from-indigo-700 hover:to-blue-700 dark:hover:from-purple-800 dark:hover:to-purple-950 transform hover:scale-105 transition-all duration-200 shadow-lg inline-block"
                       >
                         Process Files →
                       </button>
@@ -130,40 +130,40 @@ function Home() {
 
               {/* Feature Cards */}
               <div className="grid sm:grid-cols-3 gap-4 mt-12">
-                <div className="bg-gradient-to-br from-white via-purple-50 to-pink-50 backdrop-blur-sm rounded-xl p-4 transform hover:scale-105 transition-transform duration-300 shadow-lg">
+                <div className="bg-gradient-to-br from-white via-purple-50 to-pink-50 dark:from-gray-800 dark:via-gray-700 dark:to-gray-600 backdrop-blur-sm rounded-xl p-4 transform hover:scale-105 transition-transform duration-300 shadow-lg">
                   <div className="flex items-center space-x-3">
                     <div className="w-8 h-8 bg-green-500 rounded-full flex items-center justify-center">
                       <span className="text-white font-bold text-sm">✓</span>
                     </div>
-                    <span className="text-gray-700 font-medium">Expense Categorization</span>
+                    <span className="text-gray-700 dark:text-gray-200 font-medium">Expense Categorization</span>
                   </div>
                 </div>
-                <div className="bg-gradient-to-br from-white via-purple-50 to-pink-50 backdrop-blur-sm rounded-xl p-4 transform hover:scale-105 transition-transform duration-300 shadow-lg">
+                <div className="bg-gradient-to-br from-white via-purple-50 to-pink-50 dark:from-gray-800 dark:via-gray-700 dark:to-gray-600 backdrop-blur-sm rounded-xl p-4 transform hover:scale-105 transition-transform duration-300 shadow-lg">
                   <div className="flex items-center space-x-3">
                     <div className="w-8 h-8 bg-teal-500 rounded-full flex items-center justify-center">
                       <span className="text-white font-bold text-sm">📊</span>
                     </div>
-                    <span className="text-gray-700 font-medium">Trend Analysis</span>
+                    <span className="text-gray-700 dark:text-gray-200 font-medium">Trend Analysis</span>
                   </div>
                 </div>
-                <div className="bg-gradient-to-br from-white via-purple-50 to-pink-50 backdrop-blur-sm rounded-xl p-4 transform hover:scale-105 transition-transform duration-300 shadow-lg">
+                <div className="bg-gradient-to-br from-white via-purple-50 to-pink-50 dark:from-gray-800 dark:via-gray-700 dark:to-gray-600 backdrop-blur-sm rounded-xl p-4 transform hover:scale-105 transition-transform duration-300 shadow-lg">
                   <div className="flex items-center space-x-3">
                     <div className="w-8 h-8 bg-emerald-500 rounded-full flex items-center justify-center">
                       <span className="text-white font-bold text-sm">💡</span>
                     </div>
-                    <span className="text-gray-700 font-medium">Smart Recommendations</span>
+                    <span className="text-gray-700 dark:text-gray-200 font-medium">Smart Recommendations</span>
                   </div>
                 </div>
               </div>
               {/* Quick Stats Preview */}
               <div className="grid grid-cols-2 gap-4 mt-12">
-                <div className="bg-gradient-to-br from-white via-purple-50 to-pink-50 rounded-xl p-6 shadow-md text-center hover:shadow-lg transition-shadow duration-200">
+                <div className="bg-gradient-to-br from-white via-purple-50 to-pink-50 dark:from-gray-800 dark:via-gray-700 dark:to-gray-600 rounded-xl p-6 shadow-md text-center hover:shadow-lg transition-shadow duration-200">
                   <div className="text-2xl font-bold text-blue-600 mb-2">5+</div>
-                  <div className="text-sm text-gray-600">File Formats</div>
+                  <div className="text-sm text-gray-600 dark:text-gray-300">File Formats</div>
                 </div>
-                <div className="bg-gradient-to-br from-white via-purple-50 to-pink-50 rounded-xl p-6 shadow-md text-center hover:shadow-lg transition-shadow duration-200">
+                <div className="bg-gradient-to-br from-white via-purple-50 to-pink-50 dark:from-gray-800 dark:via-gray-700 dark:to-gray-600 rounded-xl p-6 shadow-md text-center hover:shadow-lg transition-shadow duration-200">
                   <div className="text-2xl font-bold text-green-600 mb-2">AI</div>
-                  <div className="text-sm text-gray-600">Powered Analysis</div>
+                  <div className="text-sm text-gray-600 dark:text-gray-300">Powered Analysis</div>
                 </div>
               </div>
             </div>
@@ -171,32 +171,32 @@ function Home() {
         </section>
         
         {/* Examples Section */}
-        <section className="py-20 bg-gradient-to-b from-white via-purple-50 to-pink-50" id="examples">
+        <section className="py-20 bg-gradient-to-b from-white via-purple-50 to-pink-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-700" id="examples">
           <div className="max-w-6xl mx-auto px-4">
-            <h2 className="text-3xl font-bold text-center text-gray-900 mb-12">
+            <h2 className="text-3xl font-bold text-center text-gray-900 dark:text-gray-100 mb-12">
               See What SpendWiseAI Can Do
             </h2>
             <div className="grid md:grid-cols-3 gap-8">
-              <div className="bg-white/80 backdrop-blur-lg p-6 rounded-3xl shadow-xl hover:shadow-2xl transition-shadow duration-300">
+              <div className="bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg p-6 rounded-3xl shadow-xl hover:shadow-2xl transition-shadow duration-300">
 
                 <ChartPanel type="bar" />
-                <h3 className="font-semibold text-gray-800 mt-4 mb-2 text-center">Visual Analytics</h3>
-                <p className="text-gray-600 text-sm text-center">Dynamic charts to visualize your spending patterns</p>
+                <h3 className="font-semibold text-gray-800 dark:text-gray-100 mt-4 mb-2 text-center">Visual Analytics</h3>
+                <p className="text-gray-600 dark:text-gray-300 text-sm text-center">Dynamic charts to visualize your spending patterns</p>
               </div>
 
 
-              <div className="bg-white/80 backdrop-blur-lg p-6 rounded-3xl shadow-xl hover:shadow-2xl transition-shadow duration-300">
+              <div className="bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg p-6 rounded-3xl shadow-xl hover:shadow-2xl transition-shadow duration-300">
 
                 <ChartPanel type="donut" />
-                <h3 className="font-semibold text-gray-800 mt-4 mb-2 text-center">Smart Insights</h3>
-                <p className="text-gray-600 text-sm text-center">AI highlights your highest spending categories</p>
+                <h3 className="font-semibold text-gray-800 dark:text-gray-100 mt-4 mb-2 text-center">Smart Insights</h3>
+                <p className="text-gray-600 dark:text-gray-300 text-sm text-center">AI highlights your highest spending categories</p>
               </div>
 
 
-              <div className="bg-white/80 backdrop-blur-lg p-6 rounded-3xl shadow-xl hover:shadow-2xl transition-shadow duration-300">
+              <div className="bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg p-6 rounded-3xl shadow-xl hover:shadow-2xl transition-shadow duration-300">
                 <TrendChart />
-                <h3 className="font-semibold text-gray-800 mt-4 mb-2 text-center">Trend Analyzer</h3>
-                <p className="text-gray-600 text-sm text-center">See how your expenses change over time</p>
+                <h3 className="font-semibold text-gray-800 dark:text-gray-100 mt-4 mb-2 text-center">Trend Analyzer</h3>
+                <p className="text-gray-600 dark:text-gray-300 text-sm text-center">See how your expenses change over time</p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- persist theme selection in `DarkModeToggle`
- adapt Card, Layout, Header and pages for dark classes
- add global body styling for gradients in light and dark
- tweak button and card colors for dark mode

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ede43cd688327afc80a5ccd76c8f3