### PR TITLE
Add constants and UI improvements

### DIFF
--- a/src/components/ChartPanel.jsx
+++ b/src/components/ChartPanel.jsx
@@ -1,18 +1,19 @@
 import React from "react";
-import { PieChart, Pie, Cell, ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip } from "recharts";
+import {
+  PieChart,
+  Pie,
+  Cell,
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+} from "recharts";
+import { MOCK_EXPENSE_DATA, MOCK_CHART_DATA } from "../constants";
 
-const dataPie = [
-  { name: "Marketing", value: 400 },
-  { name: "Travel", value: 300 },
-  { name: "Tech", value: 300 },
-];
-
-const dataBar = [
-  { name: "Jan", value: 400 },
-  { name: "Feb", value: 300 },
-  { name: "Mar", value: 500 },
-  { name: "Apr", value: 200 },
-];
+const dataPie = MOCK_EXPENSE_DATA.map((d) => ({ name: d.category, value: d.amount }));
+const dataBar = MOCK_CHART_DATA.map((d) => ({ name: d.month, value: d.Marketing + d.Travel + d.Tech }));
 
 const COLORS = ["#60a5fa", "#10b981", "#facc15"];
 

--- a/src/components/FilterDropdown.jsx
+++ b/src/components/FilterDropdown.jsx
@@ -1,9 +1,10 @@
 import React, { useState } from "react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { FunnelIcon } from "@heroicons/react/24/outline";
+import { MOCK_EXPENSE_DATA } from "../constants";
 
 function FilterDropdown({ onSelect }) {
-  const categories = ["All", "Marketing", "Travel", "Tech"];
+  const categories = ["All", ...MOCK_EXPENSE_DATA.map((d) => d.category)];
   const [value, setValue] = useState("All");
 
   const handleSelect = (category) => {

--- a/src/components/TrendChart.jsx
+++ b/src/components/TrendChart.jsx
@@ -1,12 +1,11 @@
 import React from "react";
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
+import { MOCK_CHART_DATA } from "../constants";
 
-const data = [
-  { name: "Week 1", value: 400 },
-  { name: "Week 2", value: 300 },
-  { name: "Week 3", value: 350 },
-  { name: "Week 4", value: 500 },
-];
+const data = MOCK_CHART_DATA.map((d) => ({
+  name: d.month,
+  value: d.Marketing + d.Travel + d.Tech,
+}));
 
 function TrendChart() {
   return (

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,17 @@
+export const MOCK_EXPENSE_DATA = [
+  { category: 'Marketing', amount: 1500 },
+  { category: 'Travel', amount: 700 },
+  { category: 'Tech', amount: 2000 },
+];
+
+export const MOCK_CHART_DATA = [
+  { month: 'Jan', Marketing: 800, Travel: 500, Tech: 1000 },
+  { month: 'Feb', Marketing: 1000, Travel: 700, Tech: 1300 },
+  { month: 'Mar', Marketing: 1200, Travel: 650, Tech: 1400 },
+];
+
+export const MOCK_INSIGHTS = [
+  '📈 Tech spend was the highest this quarter.',
+  '💡 Travel reduced by 22% in Feb.',
+  '⚠️ Marketing spend increased by 25% over Jan.',
+];

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -5,6 +5,7 @@ import InsightCard from "../components/InsightCard";
 import ExportButton from "../components/ExportButton";
 import FilterDropdown from "../components/FilterDropdown";
 import { useProcess } from "../context/ProcessContext";
+import { MOCK_INSIGHTS } from "../constants";
 
 function Dashboard() {
   const { isProcessed } = useProcess();
@@ -48,9 +49,9 @@ function Dashboard() {
             </div>
             <h2 className="text-lg font-semibold mt-8 mb-2">Insights</h2>
             <div className="grid md:grid-cols-3 gap-4">
-              <InsightCard text="You overspent in Tech by 32%" />
-              <InsightCard text="Marketing spend decreased 10%" />
-              <InsightCard text="Travel costs stable" />
+              {MOCK_INSIGHTS.map((text) => (
+                <InsightCard key={text} text={text} />
+              ))}
             </div>
           </>
         )}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -6,12 +6,18 @@ import TrendChart from "../components/TrendChart";
 import { useProcess } from "../context/ProcessContext";
 import PageContainer from "../components/PageContainer";
 import LoadingIndicator from "../components/LoadingIndicator";
+import InsightCard from "../components/InsightCard";
+import { MOCK_INSIGHTS } from "../constants";
 
 function Home() {
   const navigate = useNavigate();
   const [processing, setProcessing] = useState(false);
   const [uploadedFiles, setUploadedFiles] = useState([]);
   const { setIsProcessed } = useProcess();
+
+  const handleScrollToUpload = () => {
+    document.getElementById("upload-section")?.scrollIntoView({ behavior: "smooth" });
+  };
 
   const handleProcess = () => {
     if (processing) return;
@@ -107,12 +113,18 @@ function Home() {
               <h1 className="text-5xl font-bold mb-6 drop-shadow-md">
                 Welcome to <span className="text-yellow-300">SpendWiseAI</span>
               </h1>
-              <p className="text-xl mb-12 leading-relaxed opacity-90">
+              <p className="text-xl mb-6 leading-relaxed opacity-90">
                 Gain quick insights from your financial data with our intelligent analysis platform.
               </p>
+              <button
+                onClick={handleScrollToUpload}
+                className="mb-12 px-6 py-3 bg-purple-600 hover:bg-purple-700 rounded-xl shadow inline-flex items-center justify-center"
+              >
+                Upload Your Financial Files
+              </button>
 
               {/* File Upload Section */}
-              <div className="flex justify-center">
+              <div className="flex justify-center" id="upload-section">
                 <div className="w-full sm:w-3/4 md:w-2/3 lg:w-1/2 bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg rounded-3xl shadow-2xl p-8">
                   <h3 className="text-2xl font-semibold text-gray-800 dark:text-gray-100 mb-6 text-center">Get Started</h3>
                     <FileUploader onFilesChange={setUploadedFiles} />
@@ -198,6 +210,11 @@ function Home() {
                 <h3 className="font-semibold text-gray-800 dark:text-gray-100 mt-4 mb-2 text-center">Trend Analyzer</h3>
                 <p className="text-gray-600 dark:text-gray-300 text-sm text-center">See how your expenses change over time</p>
               </div>
+            </div>
+            <div className="grid md:grid-cols-3 gap-4 mt-10">
+              {MOCK_INSIGHTS.map((insight) => (
+                <InsightCard key={insight} text={insight} />
+              ))}
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- centralize mock data in constants.js
- use constants in charts and filters
- add upload scroll button and example insight cards on Home
- display insight cards from constants on Dashboard

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee9ddea288327ba5dd4bf46c40f83