### PR TITLE
Add parseFinancials API helper

### DIFF
--- a/src/api/parse.ts
+++ b/src/api/parse.ts
@@ -1,0 +1,8 @@
+import axios from "axios";
+
+const CLOUD_FUNCTION_URL = "https://us-central1-spendwise-6027f.cloudfunctions.net/parseFinancials"; // TODO: replace with your real URL
+
+export async function parseFinancials(data: string, format: 'csv' | 'json'): Promise<any[]> {
+  const resp = await axios.post(CLOUD_FUNCTION_URL, { data, format });
+  return resp.data.transactions;
+}


### PR DESCRIPTION
## Summary
- add `src/api/parse.ts` with helper function `parseFinancials`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'axios' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685094be5c2083278941c165630f3caa