### PR TITLE
Add Dashboard page

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,46 @@
+import {
+  LineChart,
+  Line,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+} from "recharts";
+
+export interface DashboardProps {
+  transactions: any[] | null;
+}
+
+export function Dashboard({ transactions }: DashboardProps) {
+  if (!transactions) {
+    return (
+      <div className="p-8 max-w-2xl mx-auto text-center text-gray-500">
+        No data yet—go back home to upload.
+      </div>
+    );
+  }
+
+  const chartData = transactions.map((t) => ({
+    date: new Date(t.date).toLocaleDateString(),
+    amount: Number(t.amount),
+  }));
+
+  return (
+    <div className="p-8 max-w-4xl mx-auto">
+      <LineChart
+        width={600}
+        height={320}
+        data={chartData}
+        className="mx-auto"
+      >
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="date" />
+        <YAxis />
+        <Tooltip />
+        <Legend />
+        <Line type="monotone" dataKey="amount" stroke="#60a5fa" />
+      </LineChart>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `Dashboard` page
- show message when transactions are null
- show a Recharts `LineChart` with axes and legend

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'firebase/firestore')*

------
https://chatgpt.com/codex/tasks/task_e_68509549eac4832788dceb233b73d5e6