### PR TITLE
Add parseFinancials Cloud Function

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -16,7 +16,8 @@
   "main": "lib/index.js",
   "dependencies": {
     "firebase-admin": "^12.6.0",
-    "firebase-functions": "^6.0.1"
+    "firebase-functions": "^6.0.1",
+    "csv-parse": "^6.3.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.12.0",


### PR DESCRIPTION
## Summary
- implement `parseFinancials` HTTP Cloud Function
- add `csv-parse` dependency for CSV handling

## Testing
- `npm install csv-parse@^6.3.0 --prefix functions` *(fails: 403 Forbidden)*
- `npm run lint --prefix functions` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6850958e7ec4832782ffdb958c8a3643