### PR TITLE
Add improved dashboard

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,46 +1,93 @@
 import {
+  ResponsiveContainer,
   LineChart,
-  Line,
   CartesianGrid,
   XAxis,
   YAxis,
   Tooltip,
-  Legend,
-} from "recharts";
+  Line,
+} from 'recharts'
+import { Link } from 'react-router-dom'
+
+export interface Transaction {
+  date: string
+  amount: number
+  description: string
+}
 
 export interface DashboardProps {
-  transactions: any[] | null;
+  transactions: Transaction[] | null
 }
 
 export function Dashboard({ transactions }: DashboardProps) {
-  if (!transactions) {
+  if (!transactions || transactions.length === 0) {
     return (
-      <div className="p-8 max-w-2xl mx-auto text-center text-gray-500">
-        No data yet—go back home to upload.
+      <div className="min-h-screen flex flex-col items-center justify-center">
+        <p className="text-gray-500 mb-4">No data yet — please upload a CSV first.</p>
+        <Link to="/" className="text-blue-500">&larr; Back to upload</Link>
       </div>
-    );
+    )
   }
 
+  const totalCount = transactions.length
+  const totalAmount = transactions.reduce((sum, t) => sum + t.amount, 0)
+
   const chartData = transactions.map((t) => ({
-    date: new Date(t.date).toLocaleDateString(),
-    amount: Number(t.amount),
-  }));
+    date: t.date,
+    amount: t.amount,
+  }))
 
   return (
-    <div className="p-8 max-w-4xl mx-auto">
-      <LineChart
-        width={600}
-        height={320}
-        data={chartData}
-        className="mx-auto"
-      >
-        <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="date" />
-        <YAxis />
-        <Tooltip />
-        <Legend />
-        <Line type="monotone" dataKey="amount" stroke="#60a5fa" />
-      </LineChart>
+    <div className="p-4 space-y-8">
+      <div className="grid grid-cols-2 gap-4">
+        <div className="bg-white rounded shadow p-4 text-center">
+          <div className="text-sm text-gray-500">Transactions</div>
+          <div className="text-2xl font-semibold">{totalCount}</div>
+        </div>
+        <div className="bg-white rounded shadow p-4 text-center">
+          <div className="text-sm text-gray-500">Total Amount</div>
+          <div className="text-2xl font-semibold">
+            {totalAmount.toLocaleString(undefined, { style: 'currency', currency: 'USD' })}
+          </div>
+        </div>
+      </div>
+
+      <div className="h-64 bg-white rounded shadow p-4">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={chartData}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="date" />
+            <YAxis />
+            <Tooltip />
+            <Line type="monotone" dataKey="amount" stroke="#3b82f6" />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-4 py-2 text-left text-sm font-medium text-gray-500">Date</th>
+              <th className="px-4 py-2 text-left text-sm font-medium text-gray-500">Description</th>
+              <th className="px-4 py-2 text-right text-sm font-medium text-gray-500">Amount</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            {transactions.map((t) => (
+              <tr key={t.date + t.description} className="bg-white odd:bg-gray-50">
+                <td className="px-4 py-2 whitespace-nowrap">
+                  {new Date(t.date).toLocaleDateString()}
+                </td>
+                <td className="px-4 py-2">{t.description}</td>
+                <td className="px-4 py-2 text-right">
+                  {t.amount.toLocaleString(undefined, { style: 'currency', currency: 'USD' })}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
-  );
+  )
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,18 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react()],
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  return {
+    plugins: [react()],
+    server: {
+      proxy: {
+        '/parseFinancials': {
+          target: env.VITE_PARSE_URL,
+          changeOrigin: true,
+        },
+      },
+    },
+  }
 })


### PR DESCRIPTION
## Summary
- rebuild Dashboard with summary cards, line chart, and transactions table
- add missing navigation link
- date formatting & stable table keys
- proxy /parseFinancials requests via Vite server

## Testing
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6850a69626b08327bc649de013af1dbe